### PR TITLE
docker: correct image name

### DIFF
--- a/book/cli/crop.md
+++ b/book/cli/crop.md
@@ -2,7 +2,7 @@
 
 To prove that an image is cropped correctly, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove crop \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest prove crop \
 --original-image=./sample/original.png \
 --cropped-image=./sample/cropped.png \
 --height-start-new=0 \
@@ -12,7 +12,7 @@ docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove crop \
 
 To verify that an image is cropped correctly, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest verify crop \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest verify crop \
 --cropped-image=./sample/cropped.png \
 --proof-dir=proofs
 ```

--- a/book/cli/flip-horizontal.md
+++ b/book/cli/flip-horizontal.md
@@ -2,7 +2,7 @@
 
 To prove that an image is correctly flipped horizontally, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove flip-horizontal \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest prove flip-horizontal \
 --original-image=./sample/original.png \
 --final-image=./sample/flipped_horizontal.png \
 --proof-dir=proofs
@@ -10,7 +10,7 @@ docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove flip-horizont
 
 To verify that an image is correctly flipped horizontally, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest verify flip-horizontal \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest verify flip-horizontal \
 --final-image=./sample/flipped_horizontal.png \
 --proof-dir=proofs
 ```

--- a/book/cli/flip-vertical.md
+++ b/book/cli/flip-vertical.md
@@ -2,7 +2,7 @@
 
 To prove that an image is correctly flipped vertically, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove flip-vertical \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest prove flip-vertical \
 --original-image=./sample/original.png \
 --final-image=./sample/flipped_vertical.png \
 --proof-dir=proofs
@@ -10,7 +10,7 @@ docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove flip-vertical
 
 To verify that an image is correctly flipped vertically, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest verify flip-vertical \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest verify flip-vertical \
 --final-image=./sample/flipped_vertical.png \
 --proof-dir=proofs
 ```

--- a/book/cli/rotate180.md
+++ b/book/cli/rotate180.md
@@ -2,7 +2,7 @@
 
 To prove that an image is correctly rotated by 180 degrees clockwise, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove rotate180 \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest prove rotate180 \
 --original-image=./sample/original.png \
 --final-image=./sample/rotated180.png \
 --proof-dir=proofs
@@ -10,7 +10,7 @@ docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove rotate180 \
 
 To verify that an image is correctly rotated by 180 degrees clockwise, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest verify rotate180 \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest verify rotate180 \
 --final-image=./sample/rotated180.png \
 --proof-dir=proofs
 ```

--- a/book/cli/rotate270.md
+++ b/book/cli/rotate270.md
@@ -2,7 +2,7 @@
 
 To prove that an image is correctly rotated by 270 degrees clockwise, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove rotate270 \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest prove rotate270 \
 --original-image=./sample/original.png \
 --final-image=./sample/rotated270.png \
 --proof-dir=proofs
@@ -10,7 +10,7 @@ docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove rotate270 \
 
 To verify that an image is correctly rotated by 270 degrees clockwise, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest verify rotate270 \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest verify rotate270 \
 --final-image=./sample/rotated270.png \
 --proof-dir=proofs
 ```

--- a/book/cli/rotate90.md
+++ b/book/cli/rotate90.md
@@ -2,7 +2,7 @@
 
 To prove that an image is correctly rotated by 90 degrees clockwise, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove rotate90 \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest prove rotate90 \
 --original-image=./sample/original.png \
 --final-image=./sample/rotated90.png \
 --proof-dir=proofs
@@ -10,7 +10,7 @@ docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove rotate90 \
 
 To verify that an image is correctly rotated by 90 degrees clockwise, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest verify rotate90 \
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest verify rotate90 \
 --final-image=./sample/rotated90.png \
 --proof-dir=proofs
 ```

--- a/book/cli/runmaya.md
+++ b/book/cli/runmaya.md
@@ -6,10 +6,10 @@ Maya CLI provides commands for both `proving` an image transformation and `verif
 
 You can also look at the available transformations for `proving` by running:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest prove --help
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest prove --help
 ```
 
 Similarly, to look at the available transformations for `verifying`, run:
 ```shell
-docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya:latest verify --help
+docker run --rm -v "$(pwd):/opt/maya" 0xmayalabs/maya-cli:latest verify --help
 ```


### PR DESCRIPTION
Replace docker image in sample doc with correct image name `0xmayalabs/maya-cli:latest`.