### PR TITLE
cmd: unify proof verification

### DIFF
--- a/cmd/brighten.go
+++ b/cmd/brighten.go
@@ -62,18 +62,16 @@ func proveBrighten(config brightenConfig) error {
 	fmt.Println("Brightening factor", brighteningFactor)
 
 	// Open the original image file.
-	originalImage, err := os.Open(config.originalImg)
+	originalImage, err := loadImage(config.originalImg)
 	if err != nil {
 		return err
 	}
-	defer originalImage.Close()
 
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the original image.
 	originalPixels, err := convertImgToPixels(originalImage)
@@ -252,11 +250,10 @@ func newVerifyBrightenCmd() *cobra.Command {
 // verifyBrighten verifies the zk proof of brightening an image by a brightening factor.
 func verifyBrighten(config verifyBrightenConfig) error {
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the final image.
 	finalPixels, err := convertImgToPixels(finalImage)

--- a/cmd/fliphorizontal.go
+++ b/cmd/fliphorizontal.go
@@ -48,18 +48,16 @@ func bindFlipHorizontalFlags(cmd *cobra.Command, conf *flipHorizontalConfig) {
 // proveFlipHorizontal generates the zk proof of flip horizontal transformation.
 func proveFlipHorizontal(config flipHorizontalConfig) error {
 	// Open the original image file.
-	originalImage, err := os.Open(config.originalImg)
+	originalImage, err := loadImage(config.originalImg)
 	if err != nil {
 		return err
 	}
-	defer originalImage.Close()
 
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the original image.
 	originalPixels, err := convertImgToPixels(originalImage)
@@ -227,11 +225,10 @@ func newVerifyFlipHorizontalCmd() *cobra.Command {
 // verifyFlipHorizontal verifies the zk proof of flip horizontal transformation.
 func verifyFlipHorizontal(config verifyFlipHorizontalConfig) error {
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the final image.
 	finalPixels, err := convertImgToPixels(finalImage)

--- a/cmd/flipvertical.go
+++ b/cmd/flipvertical.go
@@ -48,18 +48,16 @@ func bindFlipVerticalFlags(cmd *cobra.Command, conf *flipVerticalConfig) {
 // proveFlipVertical generates the zk proof of flip vertical transformation.
 func proveFlipVertical(config flipVerticalConfig) error {
 	// Open the original image file.
-	originalImage, err := os.Open(config.originalImg)
+	originalImage, err := loadImage(config.originalImg)
 	if err != nil {
 		return err
 	}
-	defer originalImage.Close()
 
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the original image.
 	originalPixels, err := convertImgToPixels(originalImage)
@@ -226,11 +224,10 @@ func newVerifyFlipVerticalCmd() *cobra.Command {
 // verifyFlipVertical verifies the zk proof of flip vertical transformation.
 func verifyFlipVertical(config verifyFlipVerticalConfig) error {
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the final image.
 	finalPixels, err := convertImgToPixels(finalImage)

--- a/cmd/rotate180.go
+++ b/cmd/rotate180.go
@@ -48,18 +48,16 @@ func bindRotate180Flags(cmd *cobra.Command, conf *rotate180Config) {
 // proveRotate180 generates the zk proof of rotated transformation 180.
 func proveRotate180(config rotate180Config) error {
 	// Open the original image file.
-	originalImage, err := os.Open(config.originalImg)
+	originalImage, err := loadImage(config.originalImg)
 	if err != nil {
 		return err
 	}
-	defer originalImage.Close()
 
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the original image.
 	originalPixels, err := convertImgToPixels(originalImage)
@@ -229,11 +227,10 @@ func newVerifyRotate180Cmd() *cobra.Command {
 // verifyRotate180Crop verifies the zk proof of rotate180 transformation.
 func verifyRotate180Crop(config verifyRotate180Config) error {
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the final image.
 	finalPixels, err := convertImgToPixels(finalImage)

--- a/cmd/rotate270.go
+++ b/cmd/rotate270.go
@@ -47,18 +47,16 @@ func bindRotate270Flags(cmd *cobra.Command, conf *rotate270Config) {
 // proveRotate270 generates the zk proof of rotated transformation 270.
 func proveRotate270(config rotate270Config) error {
 	// Open the original image file.
-	originalImage, err := os.Open(config.originalImg)
+	originalImage, err := loadImage(config.originalImg)
 	if err != nil {
 		return err
 	}
-	defer originalImage.Close()
 
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the original image.
 	originalPixels, err := convertImgToPixels(originalImage)
@@ -225,11 +223,10 @@ func newVerifyRotate270Cmd() *cobra.Command {
 // verifyRotate270 verifies the zk proof of rotate270 transformation.
 func verifyRotate270(config verifyRotate270Config) error {
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the final image.
 	finalPixels, err := convertImgToPixels(finalImage)

--- a/cmd/rotate90.go
+++ b/cmd/rotate90.go
@@ -48,18 +48,16 @@ func bindRotate90Flags(cmd *cobra.Command, conf *rotate90Config) {
 // proveRotate90 generates the zk proof of rotate 90 transformation.
 func proveRotate90(config rotate90Config) error {
 	// Open the original image file.
-	originalImage, err := os.Open(config.originalImg)
+	originalImage, err := loadImage(config.originalImg)
 	if err != nil {
 		return err
 	}
-	defer originalImage.Close()
 
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the original image.
 	originalPixels, err := convertImgToPixels(originalImage)
@@ -226,11 +224,10 @@ func newVerifyRotate90Cmd() *cobra.Command {
 // verifyRotate90 verifies the zk proof of rotate90 transformation.
 func verifyRotate90(config verifyRotate90Config) error {
 	// Open the final image file.
-	finalImage, err := os.Open(config.finalImg)
+	finalImage, err := loadImage(config.finalImg)
 	if err != nil {
 		return err
 	}
-	defer finalImage.Close()
 
 	// Get the pixel values for the final image.
 	finalPixels, err := convertImgToPixels(finalImage)


### PR DESCRIPTION
Unify transformation proof verification and add support of multiple backends.